### PR TITLE
[FIX] base, website_sale: vietnam zip not required

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -383,10 +383,14 @@ publicWidget.registry.WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
                 });
             }
 
-            $("label[for='zip']").toggleClass('label-optional', !data.zip_required);
-            $("label[for='state_id']").toggleClass('label-optional', !data.state_required);
-            $("label[for='zip']").get(0).toggleAttribute('required', !!data.zip_required);
-            $("label[for='state_id']").get(0).toggleAttribute('required', !!data.state_required);
+            if ($("label[for='zip']").length) {
+                $("label[for='zip']").toggleClass('label-optional', !data.zip_required);
+                $("label[for='zip']").get(0).toggleAttribute('required', !!data.zip_required);
+            }
+            if ($("label[for='zip']").length) {
+                $("label[for='state_id']").toggleClass('label-optional', !data.state_required);
+                $("label[for='state_id']").get(0).toggleAttribute('required', !!data.state_required);
+            }
         });
     },
     /**

--- a/odoo/addons/base/data/res_country_data.xml
+++ b/odoo/addons/base/data/res_country_data.xml
@@ -1529,6 +1529,7 @@
             <field name="code">vn</field>
             <field name="currency_id" ref="VND" />
             <field eval="84" name="phone_code" />
+            <field name='zip_required'>0</field>
             <field eval="'%(street)s\n%(street2)s\n%(city)s\n%(state_name)s %(country_name)s'" name="address_format" />
         </record>
         <record id="vu" model="res.country">


### PR DESCRIPTION
Zip cannot be required if not in format address.
It will break ecommerce, because the customer cannot
validate the address because zip code is not displayed but required.

Fix case in JS where field is not display to avoid traceback.

This commit closes PR 58950