### PR TITLE
[FIX] website_event: fix sitemap for /event/<>/community route

### DIFF
--- a/addons/website_event/controllers/community.py
+++ b/addons/website_event/controllers/community.py
@@ -7,7 +7,7 @@ from odoo.http import request
 
 class EventCommunityController(http.Controller):
 
-    @http.route('/event/<model("event.event"):event>/community', type="http", auth="public", website=True)
+    @http.route('/event/<model("event.event"):event>/community', type="http", auth="public", website=True, sitemap=False)
     def community(self, event, lang=None, **kwargs):
         """ This skeleton route will be overriden in website_event_track_quiz, website_event_meet and website_event_meet_quiz. """
         return request.render('website.page_404')


### PR DESCRIPTION
If you don't install website_event_meet_quiz or website_event_meet_quiz,
the route will not have sitemap defined.

Now we force the sitemap to False by default.
And let the override choose the presence or not into the sitemap.

It will remove the warning, if your are running test only on website_event
No Sitemap value provided for controller <bound method EventCommunityController.community of
<odoo.addons.website_event.controllers.community.EventCommunityController object at 0x7ff889bd3668>>
 (/event/<model("event.event"):event>/community)