### PR TITLE
[FIX] website: favicon use STATIC_CACHE_LONG that is a real year

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -576,5 +576,5 @@ class WebsiteBinary(http.Controller):
     def favicon(self, **kw):
         website = request.website
         response = request.redirect(website.image_url(website, 'favicon'), code=301)
-        response.headers['Cache-Control'] = 'public, max-age=%s' % (365 * 24 * 60)
+        response.headers['Cache-Control'] = 'public, max-age=%s' % http.STATIC_CACHE_LONG
         return response


### PR DESCRIPTION
365 * 24 * 60 is not a year, but year/60 ;)
While we fix it, it is the good time to change and use the dedicated
http.STATIC_CACHE_LONG that exists for it.