### PR TITLE
[FIX] website: fix recursive list in _enumerate_page

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -861,7 +861,9 @@ class Website(models.Model):
                 record['lastmod'] = page['write_date'].date()
             yield record
 
-    def _get_website_pages(self, domain=[], order='name', limit=None):
+    def _get_website_pages(self, domain=None, order='name', limit=None):
+        if domain is None:
+            domain = []
         domain += self.get_current_website().website_domain()
         pages = self.env['website.page'].sudo().search(domain, order=order, limit=limit)
         return pages


### PR DESCRIPTION
Each time the function is called, we append to the same persistent object.